### PR TITLE
change starting imagery

### DIFF
--- a/commented_bootleaf.html
+++ b/commented_bootleaf.html
@@ -329,13 +329,13 @@
                                     <div class="panel-body" style="padding: 0px 15px;">
                                         <div class="radio">
                                             <label>
-                                                <input type="radio" name="basemapLayers" id="mapquestOSM" checked>
+                                                <input type="radio" name="basemapLayers" id="mapquestOSM">
                                                 Streets
                                             </label>
                                         </div>
                                         <div class="radio">
                                             <label>
-                                                <input type="radio" name="basemapLayers" id="mapquestOAM">
+                                                <input type="radio" name="basemapLayers" id="mapquestOAM" checked>
                                                 Imagery
                                             </label>
                                         </div>


### PR DESCRIPTION
changed baseman radio buttons to start with aerial imagery checked
instead of streets.  lines 332 and 338
